### PR TITLE
Fixed preview button spelling

### DIFF
--- a/src/assets/locales.ts
+++ b/src/assets/locales.ts
@@ -90,7 +90,7 @@ const message = {
     customConfig: '自定义配置',
   },
   en: {
-    preview: 'Preiview',
+    preview: 'Preview',
     syncSite: 'Sync Website',
     newVersion: 'New version',
     article: 'Article',


### PR DESCRIPTION
Preview button in sidebar was misspelt as 'Preiview'.