### PR TITLE
fixed bug  #43

### DIFF
--- a/public/default-files/themes/simple/style-override.js
+++ b/public/default-files/themes/simple/style-override.js
@@ -2,7 +2,7 @@ const generateOverride = (params = {}) => {
   let result = ''
 
   // 侧边栏宽度 - sidebarWidth
-  if (params.sidebarWidth !== '320px') {
+  if (params.sidebarWidth && params.sidebarWidth !== '320px') {
     result += `
       .sidebar {
         width: ${params.sidebarWidth};

--- a/src/views/article/ArticleUpdate.vue
+++ b/src/views/article/ArticleUpdate.vue
@@ -82,7 +82,7 @@
       </a-row>
 
       <!-- 编辑器点击图片上传用 -->
-      <input ref="uploadInput" class="upload-input" type="file" @change="fileChangeHandler">
+      <input ref="uploadInput" class="upload-input" type="file" accept="image/*" @change="fileChangeHandler">
     </div>
   </div>
 </template>


### PR DESCRIPTION
对于 title 中包含 `[ ] { } &`特殊字符的  gray-matter 无法正常解析
对于 title 为纯数字的，再其他地方会报类型错误，统一为 string
对于 tags 为 string 的解析为 [string]