### PR TITLE
Fix markdown todo list render fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "husky": "^1.3.1",
     "less-loader": "^4.1.0",
     "lint-staged": "^8.1.5",
+    "markdown-it-task-lists": "^2.1.1",
     "typescript": "^3.0.0",
     "vue-cli-plugin-electron-builder": "^1.2.0",
     "vue-template-compiler": "^2.5.17"

--- a/src/server/plugins/markdown.ts
+++ b/src/server/plugins/markdown.ts
@@ -1,6 +1,7 @@
 import MarkdownIt from 'markdown-it'
 import MarkdownItKatex from '@iktakahiro/markdown-it-katex'
 import markdownItTocAndAnchor from 'markdown-it-toc-and-anchor'
+import MarkdownItTaskLists from 'markdown-it-task-lists'
 
 const markdownIt = new MarkdownIt({
   html: true,
@@ -9,6 +10,9 @@ const markdownIt = new MarkdownIt({
 markdownIt.use(MarkdownItKatex)
 markdownIt.use(markdownItTocAndAnchor, {
   anchorLink: false,
+})
+markdownIt.use(MarkdownItTaskLists, {
+  label: true, labelAfter: true,
 })
 
 export default markdownIt


### PR DESCRIPTION
#### 渲染<span style="color: red;">失败</span>效果：
![image](https://user-images.githubusercontent.com/26423989/57354789-08082100-719f-11e9-83fc-83e637e800ca.png)

#### 渲染<span style="color: green;">成功</span>效果：
![image](https://user-images.githubusercontent.com/26423989/57354968-88c71d00-719f-11e9-89ac-517653f361cb.png)

#### 解决方式：添加```markdown-it-task-lists``` 依赖。