### PR TITLE
feat: 使用 express 作为本地静态服务器，简化编译过程，预览更舒服

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@iktakahiro/markdown-it-katex": "^3.1.0",
+    "@types/express": "^4.17.0",
     "ant-design-vue": "^1.3.5",
     "axios": "^0.18.1",
     "bluebird": "^3.5.3",

--- a/src/background.ts
+++ b/src/background.ts
@@ -8,7 +8,7 @@ import {
 } from 'vue-cli-plugin-electron-builder/lib'
 import App from './server/app'
 import messages from './assets/locales-menu'
-import createServer from './server'
+import initServer from './server'
 
 const isDevelopment = process.env.NODE_ENV !== 'production'
 
@@ -105,12 +105,14 @@ function createWindow() {
     mainWindow: win,
     app,
     baseDir: __dirname,
+    previewServer: null,
   }
 
   // Init app
   const appInstance = new App(setting)
   console.log('Main process runing...', appInstance.appDir) // DELETE ME
-  createServer(`${appInstance.appDir}/output`)
+  const server = initServer(`${appInstance.appDir}/output`)
+  appInstance.previewServer = server
 }
 
 // Quit when all windows are closed.

--- a/src/background.ts
+++ b/src/background.ts
@@ -8,6 +8,7 @@ import {
 } from 'vue-cli-plugin-electron-builder/lib'
 import App from './server/app'
 import messages from './assets/locales-menu'
+import createServer from './server'
 
 const isDevelopment = process.env.NODE_ENV !== 'production'
 
@@ -109,6 +110,7 @@ function createWindow() {
   // Init app
   const appInstance = new App(setting)
   console.log('Main process runing...', appInstance.appDir) // DELETE ME
+  createServer(`${appInstance.appDir}/output`)
 }
 
 // Quit when all windows are closed.

--- a/src/background.ts
+++ b/src/background.ts
@@ -101,18 +101,18 @@ function createWindow() {
   menu = Menu.buildFromTemplate(template)
   Menu.setApplicationMenu(menu)
 
+  const server = initServer()
+
   const setting = {
     mainWindow: win,
     app,
     baseDir: __dirname,
-    previewServer: null,
+    previewServer: server,
   }
 
   // Init app
   const appInstance = new App(setting)
   console.log('Main process runing...', appInstance.appDir) // DELETE ME
-  const server = initServer(`${appInstance.appDir}/output`)
-  appInstance.previewServer = server
 }
 
 // Quit when all windows are closed.

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -129,7 +129,7 @@ export default class App extends Vue {
     ipcRenderer.send('html-render')
     ipcRenderer.once('html-rendered', (event: Event, result: any) => {
       this.$message.success(`🎉  ${this.$t('renderSuccess')}`)
-      this.openInBrowser(`file://${this.site.appDir}/output/index.html`)
+      this.openInBrowser('http://localhost:9999')
     })
   }
 

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -129,7 +129,13 @@ export default class App extends Vue {
     ipcRenderer.send('html-render')
     ipcRenderer.once('html-rendered', (event: Event, result: any) => {
       this.$message.success(`🎉  ${this.$t('renderSuccess')}`)
-      this.openInBrowser('http://localhost:9999')
+      ipcRenderer.send('app-preview-server-port-get')
+      ipcRenderer.once(
+        'app-preview-server-port-got',
+        (portGotEvent: Event, port: any) => {
+          this.openInBrowser(`http://localhost:${port}`)
+        },
+      )
     })
   }
 

--- a/src/helpers/content-helper.ts
+++ b/src/helpers/content-helper.ts
@@ -44,8 +44,8 @@ export default class ContentHelper {
   /**
    * 将 feature 本地图片路径，变更为线上路径
    */
-  changeFeatureImageUrlLocalToDomain(content: string, domainPath: string, mode: string) {
-    let url = content.replace(this.featureLocalReg, `${mode === 'preview' ? 'file:///' : ''}${domainPath}/post-images/`)
+  changeFeatureImageUrlLocalToDomain(content: string, domainPath: string) {
+    let url = content.replace(this.featureLocalReg, `${domainPath}/post-images/`)
     url = url.replace(/\\/g, '/')
     return url
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,21 @@
 import express from 'express'
+import http from 'http'
+import { AddressInfo } from 'net'
 
-export default function createServer(SitePath: string) {
+export default function initServer(SitePath: string) {
   const server = express()
   server.use(express.static(SitePath))
-  server.listen(9999, () => console.log('Express listening on port 9999'))
+  function listen(port: number) {
+    server.listen(port, 'localhost').on('error', (err: NodeJS.ErrnoException) => {
+      if (err) {
+        console.log(`Express port ${port} is busy, trying with port ${port + 1}`)
+        listen(port + 1)
+      }
+    }).on('listening', () => {
+      server.set('port', port)
+      console.log(`Express server is running on port : ${port}`)
+    })
+  }
+  listen(4000)
+  return server
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,7 @@
 import express from 'express'
-import http from 'http'
-import { AddressInfo } from 'net'
 
-export default function initServer(SitePath: string) {
+export default function initServer() {
   const server = express()
-  server.use(express.static(SitePath))
   function listen(port: number) {
     server.listen(port, 'localhost').on('error', (err: NodeJS.ErrnoException) => {
       if (err) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,7 @@
+import express from 'express'
+
+export default function createServer(SitePath: string) {
+  const server = express()
+  server.use(express.static(SitePath))
+  server.listen(9999, () => console.log('Express listening on port 9999'))
+}

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow, app } from 'electron'
 import * as fse from 'fs-extra'
 import * as path from 'path'
+import Antd from 'ant-design-vue'
 import EventClasses from './events/index'
 import Posts from './posts'
 import Tags from './tags'
@@ -22,6 +23,8 @@ export default class App {
 
   appDir: string
 
+  previewServer: any;
+
   db: IApplicationDb
 
   constructor(setting: IApplicationSetting) {
@@ -29,6 +32,7 @@ export default class App {
     this.app = setting.app
     this.baseDir = setting.baseDir
     this.appDir = path.join(this.app.getPath('documents'), 'gridea')
+    this.previewServer = setting.previewServer
 
     this.db = {
       posts: [],

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, app } from 'electron'
 import * as fse from 'fs-extra'
 import * as path from 'path'
 import Antd from 'ant-design-vue'
+import express from 'express'
 import EventClasses from './events/index'
 import Posts from './posts'
 import Tags from './tags'
@@ -118,7 +119,8 @@ export default class App {
       setting,
       commentSetting: commentSetting || this.db.commentSetting,
     }
-
+    
+    this.previewServer.use('/', express.static(`${this.appDir}/output`))
     this.initEvents()
     return {
       ...this.db,
@@ -142,6 +144,7 @@ export default class App {
       await fse.writeFileSync(appConfigPath, jsonString)
       const appConfig = await fse.readJsonSync(appConfigPath)
       this.appDir = appConfig.sourceFolder
+      this.previewServer.use('/', express.static(`${this.appDir}/output`))
 
       this.checkDir()
 

--- a/src/server/events/site.ts
+++ b/src/server/events/site.ts
@@ -19,5 +19,10 @@ export default class SiteEvents {
       const result = await appInstance.saveSourceFolderSetting(params)
       event.sender.send('app-source-folder-set', result)
     })
+
+    ipcMain.on('app-preview-server-port-get', async (event: Event, params: string) => {
+      const port = await appInstance.previewServer.get('port')
+      event.sender.send('app-preview-server-port-got', port)
+    })
   }
 }

--- a/src/server/interfaces/application.ts
+++ b/src/server/interfaces/application.ts
@@ -9,6 +9,7 @@ export interface IApplicationSetting {
   mainWindow: BrowserWindow
   app: any
   baseDir: string
+  previewServer: any
 }
 
 export interface IApplicationDb {

--- a/src/server/renderer.ts
+++ b/src/server/renderer.ts
@@ -34,6 +34,8 @@ export default class Renderer extends Model {
 
   git: SimpleGit
 
+  previewPort: number
+
   platformAddress = ''
 
   remoteUrl = ''
@@ -42,7 +44,7 @@ export default class Renderer extends Model {
 
   constructor(appInstance: any) {
     super(appInstance)
-
+    this.previewPort = appInstance.previewServer.get('port')
     this.loadConfig()
 
     const { setting } = this.db
@@ -60,7 +62,7 @@ export default class Renderer extends Model {
   }
 
   async preview() {
-    this.db.themeConfig.domain = 'http://localhost:9999'
+    this.db.themeConfig.domain = `http://localhost:${this.previewPort}`
     await this.renderAll()
   }
 

--- a/src/server/renderer.ts
+++ b/src/server/renderer.ts
@@ -60,14 +60,14 @@ export default class Renderer extends Model {
   }
 
   async preview() {
-    this.db.themeConfig.domain = this.outputDir
-    await this.renderAll('preview')
+    this.db.themeConfig.domain = 'http://localhost:9999'
+    await this.renderAll()
   }
 
   async publish() {
     this.db.themeConfig.domain = this.db.setting.domain
     console.log('domain', this.db.themeConfig.domain)
-    await this.renderAll('publish')
+    await this.renderAll()
     console.log('渲染完毕')
     let result = {
       success: true,
@@ -219,20 +219,20 @@ export default class Renderer extends Model {
   }
 
 
-  async renderAll(mode: string) {
+  async renderAll() {
     await this.clearOutputFolder()
-    await this.formatDataForRender(mode)
+    await this.formatDataForRender()
     await this.buildCss()
 
     // Render post list page
-    await this.renderPostList('', mode)
+    await this.renderPostList('')
 
     // Render archives page
-    await this.renderPostList('/archives', mode)
+    await this.renderPostList('/archives')
     // Render tag list page
     await this.renderTags()
     await this.renderPostDetail()
-    await this.renderTagDetail(mode)
+    await this.renderTagDetail()
     await this.copyFiles()
     await this.buildCname()
 
@@ -252,7 +252,7 @@ export default class Renderer extends Model {
   /**
    * Format data for rendering pages
    */
-  public formatDataForRender(mode: string): any {
+  public formatDataForRender(): any {
     const { themeConfig } = this.db
 
     this.postsData = this.db.posts.filter((item: IPostDb) => item.data.published)
@@ -272,13 +272,13 @@ export default class Renderer extends Model {
           title: item.data.title,
           tags: this.db.tags
             .filter((tag: ITag) => currentTags.find(i => i === tag.name))
-            .map((tag: ITag) => ({ ...tag, link: `${this.db.themeConfig.domain}/tag/${tag.slug}${mode === 'preview' ? '/index.html' : ''}` })),
+            .map((tag: ITag) => ({ ...tag, link: `${this.db.themeConfig.domain}/tag/${tag.slug}` })),
           date: item.data.date,
           dateFormat: (themeConfig.dateFormat && moment(item.data.date).format(themeConfig.dateFormat)) || item.data.date,
           feature: item.data.feature && !item.data.feature.includes('http')
-            ? `${helper.changeFeatureImageUrlLocalToDomain(item.data.feature, this.db.themeConfig.domain, mode)}`
+            ? `${helper.changeFeatureImageUrlLocalToDomain(item.data.feature, this.db.themeConfig.domain)}`
             : item.data.feature || '',
-          link: `${this.db.themeConfig.domain}/post/${item.fileName}${mode === 'preview' ? '/index.html' : ''}`,
+          link: `${this.db.themeConfig.domain}/post/${item.fileName}`,
           hideInList: (item.data.hideInList === undefined && false) || item.data.hideInList,
           stats: readingTime(content),
         }
@@ -311,12 +311,11 @@ export default class Renderer extends Model {
 
       const isSiteLink = menu.link.includes(this.db.setting.domain)
       if (isSiteLink) {
-        link = `${link}${mode === 'preview' ? '/index.html' : ''}`
+        link = `${link}`
       }
 
       return {
         ...menu,
-        link,
       }
     })
   }
@@ -324,7 +323,7 @@ export default class Renderer extends Model {
   /**
    * Render the article list, excluding hidden articles.
    */
-  public async renderPostList(extraPath?: string, mode?: string) {
+  public async renderPostList(extraPath?: string) {
     const { postPageSize, archivesPageSize } = this.db.themeConfig
 
     // Compatible: < v0.7.0
@@ -390,18 +389,18 @@ export default class Renderer extends Model {
       if (i === 0 && excludeHidePostsData.length > pageSize) {
         fse.ensureDir(`${this.outputDir}${extraPath}/page`)
 
-        renderData.pagination.next = `${this.db.themeConfig.domain}${extraPath}/page/2/${mode === 'preview' ? 'index.html' : ''}`
+        renderData.pagination.next = `${this.db.themeConfig.domain}${extraPath}/page/2/`
       } else if (i > 0 && excludeHidePostsData.length > pageSize) {
         fse.ensureDir(`${this.outputDir}${extraPath}/page/${i + 1}`)
 
         renderPath = `${this.outputDir}${extraPath}/page/${i + 1}/index.html`
 
         renderData.pagination.prev = i === 1
-          ? `${this.db.themeConfig.domain}${extraPath}/${mode === 'preview' ? 'index.html' : ''}`
-          : `${this.db.themeConfig.domain}${extraPath}/page/${i}/${mode === 'preview' ? 'index.html' : ''}`
+          ? `${this.db.themeConfig.domain}${extraPath}/`
+          : `${this.db.themeConfig.domain}${extraPath}/page/${i}/`
 
         renderData.pagination.next = (i + 1) * pageSize < excludeHidePostsData.length
-          ? `${this.db.themeConfig.domain}${extraPath}/page/${i + 2}/${mode === 'preview' ? 'index.html' : ''}`
+          ? `${this.db.themeConfig.domain}${extraPath}/page/${i + 2}/`
           : ''
       } else {
         fse.ensureDir(`${this.outputDir}${extraPath}`)
@@ -514,7 +513,7 @@ export default class Renderer extends Model {
   /**
    * Render tag detail page
    */
-  async renderTagDetail(mode?: string) {
+  async renderTagDetail() {
     const usedTags = this.db.tags.filter((tag: ITag) => tag.used)
     const { postPageSize } = this.db.themeConfig
     const excludeHidePostsData = this.postsData.filter((item: IPostRenderData) => !item.hideInList)
@@ -558,18 +557,18 @@ export default class Renderer extends Model {
         if (i === 0 && posts.length > pageSize) {
           fse.ensureDirSync(`${tagFolderPath}/page`)
 
-          renderData.pagination.next = `${tagDomainPath}/page/2/${mode === 'preview' ? 'index.html' : ''}`
+          renderData.pagination.next = `${tagDomainPath}/page/2/`
         } else if (i > 0 && posts.length > pageSize) {
           fse.ensureDirSync(`${tagFolderPath}/page/${i + 1}`)
 
           renderPath = `${tagFolderPath}/page/${i + 1}/index.html`
 
           renderData.pagination.prev = i === 1
-            ? `${tagDomainPath}${mode === 'preview' ? '/index.html' : ''}`
-            : `${tagDomainPath}/page/${i}/${mode === 'preview' ? 'index.html' : ''}`
+            ? `${tagDomainPath}`
+            : `${tagDomainPath}/page/${i}/`
 
           renderData.pagination.next = (i + 1) * pageSize < posts.length
-            ? `${tagDomainPath}/page/${i + 2}/${mode === 'preview' ? 'index.html' : ''}`
+            ? `${tagDomainPath}/page/${i + 2}/`
             : ''
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -737,6 +737,21 @@
   resolved "http://registry.npm.taobao.org/@types/bluebird/download/@types/bluebird-3.5.26.tgz#a38c438ae84fa02431d6892edf86e46edcbca291"
   integrity sha1-o4xDiuhPoCQx1oku34bkbty8opE=
 
+"@types/body-parser@*":
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.0.tgz#9f5c9d9bd04bb54be32d5eb9fc0d8c974e6cf58c"
+  integrity sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/connect@*":
+  version "3.4.32"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.32.tgz#aa0e9616b9435ccad02bc52b5b454ffc2c70ba28"
+  integrity sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/ejs@^2.6.3":
   version "2.6.3"
   resolved "http://registry.npm.taobao.org/@types/ejs/download/@types/ejs-2.6.3.tgz#b6509e9925d7eb5e95c8c73b6492e5baae7c1e6a"
@@ -746,6 +761,23 @@
   version "3.0.0"
   resolved "http://registry.npm.taobao.org/@types/events/download/@types/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc=
+
+"@types/express-serve-static-core@*":
+  version "4.16.7"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz#50ba6f8a691c08a3dd9fa7fba25ef3133d298049"
+  integrity sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==
+  dependencies:
+    "@types/node" "*"
+    "@types/range-parser" "*"
+
+"@types/express@^4.17.0":
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.0.tgz#49eaedb209582a86f12ed9b725160f12d04ef287"
+  integrity sha512-CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/serve-static" "*"
 
 "@types/fs-extra@^5.0.5":
   version "5.0.5"
@@ -796,6 +828,11 @@
   resolved "http://registry.npm.taobao.org/@types/marked/download/@types/marked-0.6.5.tgz#3cf2a56ef615dad24aaf99784ef90a9eba4e29d8"
   integrity sha1-PPKlbvYV2tJKr5l4TvkKnrpOKdg=
 
+"@types/mime@*":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
+  integrity sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "http://registry.npm.taobao.org/@types/minimatch/download/@types/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -818,6 +855,19 @@
 "@types/q@^1.5.1":
   version "1.5.1"
   resolved "http://registry.npm.taobao.org/@types/q/download/@types/q-1.5.1.tgz#48fd98c1561fe718b61733daed46ff115b496e18"
+
+"@types/range-parser@*":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
+  integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/serve-static@*":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.2.tgz#f5ac4d7a6420a99a6a45af4719f4dcd8cd907a48"
+  integrity sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/mime" "*"
 
 "@types/shortid@0.0.29":
   version "0.0.29"


### PR DESCRIPTION
### 使用 express 在 localhost 起一个静态的 http 服务器，替代之前的 file 协议预览
### 作用
- 简化渲染流程，渲染过程无需区分 preview 和 publish，避免 重复判断 `${mode === 'preview' ? 'index.html' : ''}`
- 避免 file 协议预览中出现的各种问题
- 或许后期可扩展页面热刷新功能，无需每次预览都打开一个新页面

希望能采纳。