### PR TITLE
fix switch theme custom config bug.

### DIFF
--- a/src/views/theme/includes/CustomSetting.vue
+++ b/src/views/theme/includes/CustomSetting.vue
@@ -260,7 +260,7 @@ export default class ThemeCustomSetting extends Vue {
       this.$set(this.form, key, this.site.themeCustomConfig[key])
     })
     this.currentThemeConfig.forEach((item: any) => {
-      if (!this.form[item.name]) {
+      if (this.form[item.name] === undefined) {
         this.$set(this.form, item.name, item.value)
       }
     })


### PR DESCRIPTION
发现gridea对于switch类型自定义配置保存会在以下场景中出现问题：
1. 当switch配置默认值是true，在修改为false，保存后，config文件可以保存成功，但是UI界面显示还是true

推测原因是以下代码中会过滤掉值为false配置
```javascript
if (!this.form[item.name]) {
   this.$set(this.form, item.name, item.value)
}
```
测试结果：
主要测试测主题有notes，NexT，目前内置的notes主题openPostToc会存在这个问题，next主题有多个配置存在，作者可以抽时间测试看一下。
修复后，使用以下代码修复后，已经成功解决该问题
```javascript
if (this.form[item.name] === undefined) {
  this.$set(this.form, item.name, item.value)
}
```
辛苦！！！
